### PR TITLE
添加BasicURL配置能力

### DIFF
--- a/T8AFNetworkKit.podspec
+++ b/T8AFNetworkKit.podspec
@@ -90,7 +90,7 @@ Pod::Spec.new do |s|
   #
 
   s.source_files  = "T8AFNetworkKit", "T8AFNetworkKit/**/*.{h,m}"
-  #s.exclude_files = "T8AFNetworkKit/**/*.plist"
+  #s.exclude_files = "Classes/Exclude"
 
   # s.public_header_files = "Classes/**/*.h"
 

--- a/T8AFNetworkKit.podspec
+++ b/T8AFNetworkKit.podspec
@@ -78,7 +78,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/zhangqippp/T8AFNetworkKit.git", :tag => "0.1.1" }
+  s.source       = { :git => "https://github.com/zhangqippp/T8AFNetworkKit.git", :tag => "0.1.10" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -90,7 +90,7 @@ Pod::Spec.new do |s|
   #
 
   s.source_files  = "T8AFNetworkKit", "T8AFNetworkKit/**/*.{h,m}"
-  s.exclude_files = "Classes/Exclude"
+  s.exclude_files = "T8AFNetworkKit/**/*.plist"
 
   # s.public_header_files = "Classes/**/*.h"
 

--- a/T8AFNetworkKit.podspec
+++ b/T8AFNetworkKit.podspec
@@ -90,7 +90,7 @@ Pod::Spec.new do |s|
   #
 
   s.source_files  = "T8AFNetworkKit", "T8AFNetworkKit/**/*.{h,m}"
-  s.exclude_files = "T8AFNetworkKit/**/*.plist"
+  #s.exclude_files = "T8AFNetworkKit/**/*.plist"
 
   # s.public_header_files = "Classes/**/*.h"
 
@@ -103,7 +103,7 @@ Pod::Spec.new do |s|
   #  non-essential files like tests, examples and documentation.
   #
 
-  # s.resource  = "icon.png"
+  s.resource  = "T8AFNetworkKit/**/*.plist"
   # s.resources = "Resources/*.png"
 
   # s.preserve_paths = "FilesToSave", "MoreFilesToSave"

--- a/T8AFNetworkKit/T8BaseNetworkService.h
+++ b/T8AFNetworkKit/T8BaseNetworkService.h
@@ -54,6 +54,8 @@ typedef void(^RequestSuccessHandleBlock)(NSDictionary *data);
 
 //  设置哪些请求的result值可以为null
 + (void)setNullableURLS:(NSArray *)nullableURLs;
+//  设置path的baseURL
++ (void)setBaseURLOfPaths:(NSDictionary *)baseURLOfPaths;
 
 + (NSURLSessionDataTask *)sendRequestUrlPath:(NSString *)strUrlPath httpMethod:(HttpMethod)httpMethod dictParams:(NSMutableDictionary *)dictParams completeBlock:(RequestComplete)completeBlock;
 

--- a/T8AFNetworkKit/T8BaseNetworkService.m
+++ b/T8AFNetworkKit/T8BaseNetworkService.m
@@ -38,7 +38,7 @@ static NSDictionary *T8BaseURLOfPaths;
         shareInstance.operationQueue.maxConcurrentOperationCount = 10;
         
         if (!T8BaseURLOfPaths) {
-            T8BaseURLOfPaths = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[T8BaseNetworkService class]] pathForResource:kBaseURLOfPathsFile ofType:nil]];
+            T8BaseURLOfPaths = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:kBaseURLOfPathsFile ofType:nil]];
         }
     });
     

--- a/T8AFNetworkKit/T8BaseNetworkService.m
+++ b/T8AFNetworkKit/T8BaseNetworkService.m
@@ -465,7 +465,7 @@ static NSDictionary *T8BaseURLOfPaths;
             }
         }
         
-        return [NSString stringWithFormat:@"%@/%@", baseURL, path];
+        return [baseURL stringByAppendingPathComponent:path];
     }else{
         return path;
     }

--- a/T8AFNetworkKit/T8BaseNetworkService.m
+++ b/T8AFNetworkKit/T8BaseNetworkService.m
@@ -12,6 +12,8 @@
 #define NSLog(FORMAT, ...) printf("%s\n", [[NSString stringWithFormat:FORMAT, ##__VA_ARGS__] UTF8String]);
 #endif
 
+#define kBaseURLOfPathsFile @"baseURLOfPaths.plist"
+
 static NSString *T8BaseNetworkUrl = nil;
 static RequestHandleBlock T8RequestHandleBlock = nil;
 static RequestManagerBlock T8RequestManagerBlock = nil;
@@ -35,7 +37,9 @@ static NSDictionary *T8BaseURLOfPaths;
         shareInstance.requestSerializer.timeoutInterval = 10;
         shareInstance.operationQueue.maxConcurrentOperationCount = 10;
         
-        T8BaseURLOfPaths = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"baseURLOfPaths" ofType:@"plist"]];
+        if (!T8BaseURLOfPaths) {
+            T8BaseURLOfPaths = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[T8BaseNetworkService class]] pathForResource:kBaseURLOfPathsFile ofType:nil]];
+        }
     });
     
     return shareInstance;
@@ -455,7 +459,7 @@ static NSDictionary *T8BaseURLOfPaths;
     if (T8BaseNetworkUrl.length>0) {
         NSString *baseURL = T8BaseNetworkUrl;
         if (T8BaseURLOfPaths && T8BaseURLOfPaths.count > 0) {
-            NSString *baseURL = [T8BaseURLOfPaths objectForKey:path];
+            baseURL = [T8BaseURLOfPaths objectForKey:path];
             if (!baseURL || baseURL.length <= 0) {
                 baseURL = T8BaseNetworkUrl;
             }

--- a/T8AFNetworkKit/T8BaseRequestAgent.h
+++ b/T8AFNetworkKit/T8BaseRequestAgent.h
@@ -7,10 +7,10 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "T8Request.h"
+#import "T8RequestAgent.h"
 
 
-@interface T8BaseRequestAgent : NSObject <T8RequestAgent>
+@interface T8BaseRequestAgent : T8RequestAgent
 
 + (T8BaseRequestAgent *)sharedBaseRequestAgent;
 

--- a/T8AFNetworkKit/T8BaseRequestAgent.m
+++ b/T8AFNetworkKit/T8BaseRequestAgent.m
@@ -8,16 +8,7 @@
 
 #import "T8BaseRequestAgent.h"
 
-@interface T8BaseRequestAgent ()
-{
-    NSMutableSet *_requests;   //  请求池
-}
-
-@end
-
 @implementation T8BaseRequestAgent
-
-@synthesize requests = _requests;
 
 + (T8BaseRequestAgent *)sharedBaseRequestAgent
 {
@@ -28,42 +19,6 @@
     });
     
     return sharedBaseRequestAgent;
-}
-
-- (id)init
-{
-    self = [super init];
-    if (self) {
-        _requests = [[NSMutableSet alloc] init];
-    }
-    
-    return self;
-}
-
-- (void)addRequest:(id<T8Request>)request
-{
-    if (request) {
-        [_requests addObject:request];
-    }
-}
-
-- (void)removeRequest:(id<T8Request>)request
-{
-    if (request) {
-        [_requests removeObject:request];
-    }
-}
-
-- (void)removeAllRequests
-{
-    [_requests removeAllObjects];
-}
-
-- (void)cancelAllRequests
-{
-    for (id<T8Request> request in _requests) {
-        [request cancel];
-    }
 }
 
 @end

--- a/T8AFNetworkKit/T8BatchRequestAgent.h
+++ b/T8AFNetworkKit/T8BatchRequestAgent.h
@@ -7,10 +7,10 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "T8Request.h"
+#import "T8RequestAgent.h"
 
 
-@interface T8BatchRequestAgent : NSObject <T8RequestAgent>
+@interface T8BatchRequestAgent : T8RequestAgent
 
 + (T8BatchRequestAgent *)sharedBatchRequestAgent;
 

--- a/T8AFNetworkKit/T8BatchRequestAgent.m
+++ b/T8AFNetworkKit/T8BatchRequestAgent.m
@@ -9,16 +9,7 @@
 #import "T8BatchRequestAgent.h"
 
 
-@interface T8BatchRequestAgent ()
-{
-    NSMutableSet *_requests;   //  请求池
-}
-
-@end
-
 @implementation T8BatchRequestAgent
-
-@synthesize requests = _requests;
 
 + (T8BatchRequestAgent *)sharedBatchRequestAgent
 {
@@ -29,42 +20,6 @@
     });
     
     return sharedBatchRequestAgent;
-}
-
-- (id)init
-{
-    self = [super init];
-    if (self) {
-        _requests = [[NSMutableSet alloc] init];
-    }
-    
-    return self;
-}
-
-- (void)addRequest:(id<T8Request>)request
-{
-    if (request) {
-        [_requests addObject:request];
-    }
-}
-
-- (void)removeRequest:(id<T8Request>)request
-{
-    if (request) {
-        [_requests removeObject:request];
-    }
-}
-
-- (void)removeAllRequests
-{
-    [_requests removeAllObjects];
-}
-
-- (void)cancelAllRequests
-{
-    for (id<T8Request> request in _requests) {
-        [request cancel];
-    }
 }
 
 @end

--- a/T8AFNetworkKit/T8ChainRequestAgent.h
+++ b/T8AFNetworkKit/T8ChainRequestAgent.h
@@ -7,10 +7,10 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "T8Request.h"
+#import "T8RequestAgent.h"
 
 
-@interface T8ChainRequestAgent : NSObject <T8RequestAgent>
+@interface T8ChainRequestAgent : T8RequestAgent
 
 + (T8ChainRequestAgent *)sharedChainRequestAgent;
 

--- a/T8AFNetworkKit/T8ChainRequestAgent.m
+++ b/T8AFNetworkKit/T8ChainRequestAgent.m
@@ -9,16 +9,7 @@
 #import "T8ChainRequestAgent.h"
 
 
-@interface T8ChainRequestAgent ()
-{
-    NSMutableSet *_requests;   //  请求池
-}
-
-@end
-
 @implementation T8ChainRequestAgent
-
-@synthesize requests = _requests;
 
 + (T8ChainRequestAgent *)sharedChainRequestAgent
 {
@@ -29,42 +20,6 @@
     });
     
     return sharedChainRequestAgent;
-}
-
-- (id)init
-{
-    self = [super init];
-    if (self) {
-        _requests = [[NSMutableSet alloc] init];
-    }
-    
-    return self;
-}
-
-- (void)addRequest:(id<T8Request>)request
-{
-    if (request) {
-        [_requests addObject:request];
-    }
-}
-
-- (void)removeRequest:(id<T8Request>)request
-{
-    if (request) {
-        [_requests removeObject:request];
-    }
-}
-
-- (void)removeAllRequests
-{
-    [_requests removeAllObjects];
-}
-
-- (void)cancelAllRequests
-{
-    for (id<T8Request> request in _requests) {
-        [request cancel];
-    }
 }
 
 @end

--- a/T8AFNetworkKit/T8RequestAgent.h
+++ b/T8AFNetworkKit/T8RequestAgent.h
@@ -9,15 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "T8Request.h"
 
-@interface T8RequestAgent : NSObject
-
-//  添加请求
-- (void)addRequest:(id<T8Request>)request;
-//  移除请求
-- (void)removeRequest:(id<T8Request>)request;
-//  清空所有请求
-- (void)removeAllRequests;
-//  取消所有请求
-- (void)cancelAllRequests;
+@interface T8RequestAgent : NSObject <T8RequestAgent>
 
 @end

--- a/T8AFNetworkKit/T8RequestAgent.m
+++ b/T8AFNetworkKit/T8RequestAgent.m
@@ -12,9 +12,10 @@
 
 @interface T8RequestAgent ()
 {
-    NSMutableSet *_requests;   //  请求池
     pthread_mutex_t _lock;
 }
+
+@property (nonatomic, strong, readwrite) NSMutableSet *requests;    //  请求池
 
 @end
 

--- a/T8AFNetworkKit/T8UploadFileRequestAgent.h
+++ b/T8AFNetworkKit/T8UploadFileRequestAgent.h
@@ -7,10 +7,10 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "T8Request.h"
+#import "T8RequestAgent.h"
 
 
-@interface T8UploadFileRequestAgent : NSObject <T8RequestAgent>
+@interface T8UploadFileRequestAgent : T8RequestAgent
 
 + (T8UploadFileRequestAgent *)sharedUploadFileRequestAgent;
 

--- a/T8AFNetworkKit/T8UploadFileRequestAgent.m
+++ b/T8AFNetworkKit/T8UploadFileRequestAgent.m
@@ -9,16 +9,7 @@
 #import "T8UploadFileRequestAgent.h"
 
 
-@interface T8UploadFileRequestAgent ()
-{
-    NSMutableSet *_requests;   //  请求池
-}
-
-@end
-
 @implementation T8UploadFileRequestAgent
-
-@synthesize requests = _requests;
 
 + (T8UploadFileRequestAgent *)sharedUploadFileRequestAgent
 {
@@ -29,42 +20,6 @@
     });
     
     return sharedUploadFileRequestAgent;
-}
-
-- (id)init
-{
-    self = [super init];
-    if (self) {
-        _requests = [[NSMutableSet alloc] init];
-    }
-    
-    return self;
-}
-
-- (void)addRequest:(id<T8Request>)request
-{
-    if (request) {
-        [_requests addObject:request];
-    }
-}
-
-- (void)removeRequest:(id<T8Request>)request
-{
-    if (request) {
-        [_requests removeObject:request];
-    }
-}
-
-- (void)removeAllRequests
-{
-    [_requests removeAllObjects];
-}
-
-- (void)cancelAllRequests
-{
-    for (id<T8Request> request in _requests) {
-        [request cancel];
-    }
 }
 
 @end

--- a/T8AFNetworkKit/baseURLOfPaths.plist
+++ b/T8AFNetworkKit/baseURLOfPaths.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>passport/accesstoken/get</key>
+	<string>http://123.56.100.23:8080/bloodstone</string>
+</dict>
+</plist>

--- a/T8AFNetworkKit/baseURLOfPaths.plist
+++ b/T8AFNetworkKit/baseURLOfPaths.plist
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>passport/accesstoken/get</key>
-	<string>http://123.56.100.23:8080/bloodstone</string>
 </dict>
 </plist>

--- a/T8AFNetworkKit/baseURLOfPaths.plist
+++ b/T8AFNetworkKit/baseURLOfPaths.plist
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>passport/accesstoken/get</key>
-	<string>http://123.56.100.23:8080/bloodstone</string>
-</dict>
+<dict/>
 </plist>

--- a/T8AFNetworkKitDemo/T8AFNetworkKitDemo.xcodeproj/project.pbxproj
+++ b/T8AFNetworkKitDemo/T8AFNetworkKitDemo.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		11913FCC1D364685007FDADD /* T8BaseRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 11913FC61D364685007FDADD /* T8BaseRequest.m */; };
 		11913FCD1D364685007FDADD /* T8BatchRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 11913FC81D364685007FDADD /* T8BatchRequest.m */; };
 		11913FCE1D364685007FDADD /* T8ChainRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 11913FCA1D364685007FDADD /* T8ChainRequest.m */; };
+		11D22C951ECD7CC300AA0507 /* baseURLOfPaths.plist in Resources */ = {isa = PBXBuildFile; fileRef = 11D22C941ECD7CC300AA0507 /* baseURLOfPaths.plist */; };
 		6DB9EF3D1B19B21200355150 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DB9EF3C1B19B21200355150 /* main.m */; };
 		6DB9EF401B19B21200355150 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DB9EF3F1B19B21200355150 /* AppDelegate.m */; };
 		6DB9EF431B19B21200355150 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DB9EF421B19B21200355150 /* ViewController.m */; };
@@ -62,6 +63,7 @@
 		11913FC91D364685007FDADD /* T8ChainRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = T8ChainRequest.h; sourceTree = "<group>"; };
 		11913FCA1D364685007FDADD /* T8ChainRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = T8ChainRequest.m; sourceTree = "<group>"; };
 		11913FCB1D364685007FDADD /* T8Request.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = T8Request.h; sourceTree = "<group>"; };
+		11D22C941ECD7CC300AA0507 /* baseURLOfPaths.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = baseURLOfPaths.plist; sourceTree = "<group>"; };
 		6DB9EF371B19B21200355150 /* T8AFNetworkKitDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = T8AFNetworkKitDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6DB9EF3B1B19B21200355150 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6DB9EF3C1B19B21200355150 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -173,16 +175,17 @@
 		6DC395DA1B1BFCF100270D0D /* T8AFNetworkKit */ = {
 			isa = PBXGroup;
 			children = (
+				1111ADD11E66D3CE009FC749 /* T8AFNetworkKit.h */,
+				11913FCB1D364685007FDADD /* T8Request.h */,
 				11585AAD1E76A0DE005C0CF8 /* T8RequestAgent.h */,
 				11585AAE1E76A0DE005C0CF8 /* T8RequestAgent.m */,
-				1111ADD11E66D3CE009FC749 /* T8AFNetworkKit.h */,
 				1111ADC51E66D3A4009FC749 /* T8BaseRequestAgent.h */,
-				1111ADC61E66D3A4009FC749 /* T8BatchRequestAgent.h */,
-				1111ADC71E66D3A4009FC749 /* T8ChainRequestAgent.h */,
-				1111ADC81E66D3A4009FC749 /* T8UploadFileRequestAgent.h */,
 				1111ADC91E66D3A4009FC749 /* T8BaseRequestAgent.m */,
+				1111ADC61E66D3A4009FC749 /* T8BatchRequestAgent.h */,
 				1111ADCA1E66D3A4009FC749 /* T8BatchRequestAgent.m */,
+				1111ADC71E66D3A4009FC749 /* T8ChainRequestAgent.h */,
 				1111ADCB1E66D3A4009FC749 /* T8ChainRequestAgent.m */,
+				1111ADC81E66D3A4009FC749 /* T8UploadFileRequestAgent.h */,
 				1111ADCC1E66D3A4009FC749 /* T8UploadFileRequestAgent.m */,
 				11913FC51D364685007FDADD /* T8BaseRequest.h */,
 				11913FC61D364685007FDADD /* T8BaseRequest.m */,
@@ -190,13 +193,13 @@
 				11913FC81D364685007FDADD /* T8BatchRequest.m */,
 				11913FC91D364685007FDADD /* T8ChainRequest.h */,
 				11913FCA1D364685007FDADD /* T8ChainRequest.m */,
-				11913FCB1D364685007FDADD /* T8Request.h */,
 				6DC395DB1B1BFCF100270D0D /* T8BaseNetworkService.h */,
 				6DC395DC1B1BFCF100270D0D /* T8BaseNetworkService.m */,
 				6DC395DD1B1BFCF100270D0D /* T8NetworkError.h */,
 				6DC395DE1B1BFCF100270D0D /* T8NetworkError.m */,
 				116B0CF21D61EC65007037FE /* T8UploadFileRequest.h */,
 				116B0CF31D61EC65007037FE /* T8UploadFileRequest.m */,
+				11D22C941ECD7CC300AA0507 /* baseURLOfPaths.plist */,
 			);
 			name = T8AFNetworkKit;
 			path = ../../T8AFNetworkKit;
@@ -304,6 +307,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6DB9EF461B19B21200355150 /* Main.storyboard in Resources */,
+				11D22C951ECD7CC300AA0507 /* baseURLOfPaths.plist in Resources */,
 				6DB9EF4B1B19B21200355150 /* LaunchScreen.xib in Resources */,
 				6DB9EF481B19B21200355150 /* Images.xcassets in Resources */,
 				116B0CF61D61F2A4007037FE /* 0578.png in Resources */,


### PR DESCRIPTION
1. 整理RequestAgent代码
2. 添加BasicURL配置能力（通过设置T8BaseURLOfPaths，在生成request时根据不同的subPath使用不同的baseURL）
3. 手动设置T8BaseURLOfPaths后通过plist文件配置的信息将失效
4. 修改请求路径的拼接方式（采用系统提供的appendPath方法）